### PR TITLE
Refactor dotfiles and remove Ruby setup

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -32,9 +32,6 @@ area/macos:
 area/python:
   - "python/**/*"
 
-area/ruby:
-  - "ruby/**/*"
-
 area/tests:
   - "tests/**/*"
 

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -44,10 +44,6 @@
   color: "7BD7E0"
   description: "Changes made to the Python dotfile"
 
-- name: area/ruby
-  color: "7BD7E0"
-  description: "Changes made to the Ruby dotfile"
-
 - name: area/tests
   color: "7BD7E0"
   description: "Changes made to test resources"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone --recurse-submodules https://github.com/l50/dotfiles.git
   git clone https://github.com/asdf-vm/asdf.git ~/.asdf
   ```
 
-- Install and use asdf plugins to manage go, python, and ruby for this project:
+- Install and use asdf plugins to manage go and python for this project:
 
   ```bash
   source .asdf

--- a/bashutils
+++ b/bashutils
@@ -99,7 +99,10 @@ rr() {
   fi
 }
 
-alias repo_root='rr'
+# Maintain backwards compatibility with old function name
+repo_root() {
+  rr
+}
 
 # Extracts only the comments from the contents of the specified file or from stdin.
 # It supports extracting single-line comments that start with // or #, as

--- a/files/default-golang-pkgs
+++ b/files/default-golang-pkgs
@@ -16,6 +16,9 @@ github.com/charmbracelet/glow
 // Deliver Go binaries as fast and easily as possible
 github.com/goreleaser/goreleaser@latest
 
+// lf (as in "list files") is a terminal file manager written in Go
+github.com/gokcehan/lf@latest
+
 // VSCode Go extension tools
 golang.org/x/tools/gopls@latest
 github.com/cweill/gotests/gotests@latest

--- a/go
+++ b/go
@@ -1,18 +1,4 @@
-# Get helper func from setup_asdf.sh
-# shellcheck source=/dev/null
-source "${HOME}/.dotfiles/files/setup_asdf.sh"
-source "$HOME/.asdf/asdf.sh"
-
-# Define go version from global .tool-versions file
-setup_language "golang" "global"
-
-# Set and export environment variables
-GOPATH=$(go env GOPATH)
-GOROOT=$(go env GOROOT)
 FILES="${HOME}/.dotfiles/files"
-
-export GOPATH GOROOT FILES
-export PATH=$PATH:$GOPATH/bin:$GOROOT/bin
 
 export GOSUMDB=sum.golang.org
 export GOPROXY=https://proxy.golang.org,direct
@@ -186,8 +172,3 @@ if [[ $RUNNING_BATS_TEST != 1 ]]; then
 fi
 
 add_cobra_init
-
-# Install lf if it's not already installed
-if ! command -v lf &> /dev/null; then
-    env CGO_ENABLED=0 go install -ldflags="-s -w" github.com/gokcehan/lf@latest
-fi

--- a/install_dot_files.sh
+++ b/install_dot_files.sh
@@ -24,7 +24,6 @@ declare -a files=(
     'keeper'
     'k8s'
     'python'
-    'ruby'
     'macos'
 )
 
@@ -157,10 +156,6 @@ android_sec_tools_folder
 
 # Move files from install directory into $DOT_DIR
 cp -r "${INSTALL_DIR}/files" "${DOT_DIR}/files"
-cp -r "${INSTALL_DIR}/.tool-versions" "${DOT_DIR}/.tool-versions"
-
-# Move .tool-versions file into place
-cp "${DOT_DIR}/.tool-versions" "${HOME}/.tool-versions"
 
 # Move asdf default package files into place
 cp "${DOT_DIR}/files/default-golang-pkgs" "${HOME}/.default-golang-pkgs"

--- a/python
+++ b/python
@@ -1,10 +1,3 @@
-# Get helper func from setup_asdf.sh
-# shellcheck source=/dev/null
-source "${HOME}/.dotfiles/files/setup_asdf.sh"
-
-# Define python version from global .tool-versions file
-setup_language "python" "global"
-
 # venv
 alias venv_activate="source .venv/bin/activate"
 alias venv_deactivate="deactivate"

--- a/ruby
+++ b/ruby
@@ -1,5 +1,0 @@
-# Get helper func from setup_asdf.sh
-# shellcheck source=/dev/null
-source "${HOME}/.dotfiles/files/setup_asdf.sh"
-# Define ruby version from global .tool-versions file
-setup_language "ruby" "global"

--- a/zshrc
+++ b/zshrc
@@ -9,7 +9,7 @@ export plugins=(asdf git docker helm kubectl)
 
 # Source other dotfiles
 for file in "${HOME}/.dotfiles"/*; do
-  if [[ -f "${file}" && -r "${file}" && "${file}" != "ruby" ]]; then
+  if [[ -f "${file}" && -r "${file}" ]]; then
     # shellcheck source=/dev/null
     source "${file}"
   fi


### PR DESCRIPTION
**Added:**

- Added lf (terminal file manager) to default Go packages.

**Changed:**

- Refactored function `rr` to a direct function instead of alias in bashutils.
- Updated README to reflect removal of Ruby from asdf plugins management.
- Simplified environment setup in go and python scripts.
- Updated GitHub labeler and labels configuration to remove Ruby references.
- Adjusted zshrc file sourcing logic to include all readable files.

**Removed:**

- Removed Ruby setup and management across dotfiles.
- Deleted Ruby specific labels in GitHub configuration.
- Eliminated Ruby related files and references in installation scripts.