### PR TITLE
feat: enhance largest_files utility with flexible arguments and improved output

### DIFF
--- a/tests/test-bashutils.bats
+++ b/tests/test-bashutils.bats
@@ -318,7 +318,7 @@ EOF
 
 @test "dictionary_without_curl" {
 	# Mock command to simulate curl not being installed
-	# shellcheck disable=SC2317
+	# shellcheck disable=SC2317,SC2329
 	command() {
 		# shellcheck disable=SC2317
 		if [[ "$2" == "curl" ]]; then
@@ -340,7 +340,7 @@ EOF
 
 @test "dictionary_without_jq" {
 	# Mock command to simulate jq not being installed
-	# shellcheck disable=SC2317
+	# shellcheck disable=SC2317,SC2329
 	command() {
 		# shellcheck disable=SC2317
 		if [[ "$2" == "jq" ]]; then

--- a/tests/test-macos.bats
+++ b/tests/test-macos.bats
@@ -42,8 +42,16 @@ teardown() {
 	assert_success
 
 	# Check if output contains the expected filename and size format
-	[[ "$output" == *"large_file.dat: "* ]] || {
-		echo "Expected output to contain 'large_file.dat: ' followed by size"
+	# Format is: SIZE FILEPATH (e.g., "200.0M /path/to/large_file.dat")
+	[[ "$output" == *"large_file.dat"* ]] || {
+		echo "Expected output to contain 'large_file.dat'"
+		echo "Actual output: $output"
+		return 1
+	}
+
+	# Verify the output contains a size in megabytes
+	[[ "$output" == *"M "* ]] || {
+		echo "Expected output to contain size in MB format"
 		echo "Actual output: $output"
 		return 1
 	}


### PR DESCRIPTION
**Key Changes:**

- Upgraded largest_files to support customizable count and minimum size arguments
- Enhanced output formatting with human-readable file sizes and improved sorting
- Updated documentation and usage examples for clarity and flexibility
- Improved related test coverage to validate new output format and argument handling

**Added:**

- Support for specifying the number of results and minimum file size (in MB) as
  arguments to largest_files, enabling flexible file searches
- Output formatting that displays file sizes in human-readable units (K/M/G/B)
- Documentation of new arguments, usage examples, and clearer in-function
  comments for largest_files

**Changed:**

- largest_files implementation refactored to use find with -ls and sort, greatly
  improving speed and accuracy over previous per-file shell invocation
- Output format changed to show size first (e.g., "200.0M /path/to/file") and
  sorted by size descending
- Test for largest_files updated to check for presence of the filename and for
  size in MB format, reflecting the new output style and argument support
- shellcheck disables in test-bashutils.bats expanded to suppress new warnings
  for command mocking functions

**Removed:**

- Deprecated output style showing "<filename>: <size>" in favor of new format
- Unused resource comment from largest_files documentation block