### PR TITLE
feat: enhance 1password cli integration and scripts

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -71,7 +71,7 @@ area/keeper:
       - any-glob-to-any-file: "keeper"
 area/1password:
   - changed-files:
-      - any-glob-to-any-file: "op"
+      - any-glob-to-any-file: "op.sh"
 
 # Platform Specific
 area/android:

--- a/op
+++ b/op
@@ -1,2 +1,0 @@
-# OnePassword plugins
-source $HOME/.config/op/plugins.sh

--- a/op.sh
+++ b/op.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# 1Password CLI completions (zsh only)
+if [[ -n "$ZSH_VERSION" ]] && command -v op &> /dev/null; then
+    eval "$(op completion zsh)"
+fi
+
+# 1Password shell plugins (biometric auth for CLIs like gh, aws)
+# Initialize new plugins with: op plugin init <tool>
+[[ -f "$HOME/.config/op/plugins.sh" ]] && source "$HOME/.config/op/plugins.sh"
+
+# Quick secret read
+# Usage: opsecret "Private/Database/password"
+opsecret() {
+    op read "op://$1"
+}
+
+# Copy a 1Password secret to clipboard
+# Usage: opcp "Private/Database/password"
+opcp() {
+    op read "op://$1" | pbcopy && echo "Copied to clipboard."
+}
+
+# Run a command with secrets injected from an env file
+# Usage: oprun .env.dev ./start-server
+oprun() {
+    op run --env-file "${1:-.env}" -- "${@:2}"
+}


### PR DESCRIPTION
**Key Changes:**

- Replaced legacy `op` script with new `op.sh` featuring extended 1Password CLI helpers
- Added shell functions for secret retrieval, clipboard copying, and env-injected commands
- Updated labeler configuration to track changes in the new `op.sh` script

**Added:**

- New `op.sh` script providing:
  - 1Password CLI completion for zsh
  - Automatic sourcing of 1Password shell plugins for biometric auth
  - `opsecret` function for easy secret retrieval
  - `opcp` function to copy secrets directly to clipboard
  - `oprun` function to inject secrets into commands using an env file

**Changed:**

- Labeler configuration now associates the `area/1password` label with changes to `op.sh`
  instead of the old `op` script

**Removed:**

- Legacy `op` script that only sourced shell plugins, replaced by the more
  comprehensive `op.sh` script