### PR TITLE
ci: enable automerge for pre-commit hook updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,13 @@
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Auto-merge pre-commit hooks",
+      "matchManagers": ["pre-commit"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "npm": {


### PR DESCRIPTION
**Key Changes:**

- Enabled Renovate automerge for pre-commit hook dependency updates
- Limited automatic updates to minor and patch versions to reduce upgrade risk
- Configured updates to merge through pull requests for consistent review flow

**Added:**

- Pre-commit hook update automation - Added a Renovate package rule in `.github/renovate.json5` to automerge minor and patch updates managed by `pre-commit`