### PR TITLE
feat: make ansible roles opt-in and improve installer resilience

### DIFF
--- a/bashutils.sh
+++ b/bashutils.sh
@@ -892,7 +892,7 @@ alias networkedComputers="arp -a |grep -oP '\d+\.\d+\.\d+\.\d+'"
 
 # If gshuf and cowsay are installed, then evolve our vocab with cowsay
 # https://www.quora.com/What-is-the-most-interesting-shell-script-you-have-ever-written
-if hash cowsay 2> /dev/null && hash gshuf 2> /dev/null; then
+if hash cowsay 2> /dev/null && hash gshuf 2> /dev/null && [[ -f "$HOME/.dotfiles/files/gre" ]]; then
     gshuf -n 1 "$HOME/.dotfiles/files/gre" | cowsay
 fi
 

--- a/bashutils.sh
+++ b/bashutils.sh
@@ -890,12 +890,6 @@ generate_pr() {
 
 alias networkedComputers="arp -a |grep -oP '\d+\.\d+\.\d+\.\d+'"
 
-# If gshuf and cowsay are installed, then evolve our vocab with cowsay
-# https://www.quora.com/What-is-the-most-interesting-shell-script-you-have-ever-written
-if hash cowsay 2> /dev/null && hash gshuf 2> /dev/null && [[ -f "$HOME/.dotfiles/files/gre" ]]; then
-    gshuf -n 1 "$HOME/.dotfiles/files/gre" | cowsay
-fi
-
 # Set alias for nmap if it's installed
 # https://github.com/hriesco/dotfiles/blob/master/.aliases
 if hash nmap 2> /dev/null; then

--- a/go.sh
+++ b/go.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-FILES="${HOME}/.dotfiles/files"
+FILES="${HOME}/.dotfiles/config"
 
 export GOSUMDB=sum.golang.org
 export GOPROXY=https://proxy.golang.org,direct

--- a/install_dot_files.sh
+++ b/install_dot_files.sh
@@ -28,34 +28,19 @@ INSTALL_CLAUDE=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --skip-ansible)
-            RUN_ANSIBLE=false
-            shift
-            ;;
-        --install-alloy)
-            INSTALL_ALLOY=true
-            shift
-            ;;
-        --install-mise)
-            INSTALL_MISE=true
-            shift
-            ;;
-        --install-go-task)
-            INSTALL_GO_TASK=true
-            shift
-            ;;
-        --install-claude)
-            INSTALL_CLAUDE=true
-            shift
-            ;;
+        --skip-ansible) RUN_ANSIBLE=false ;;
+        --install-alloy) INSTALL_ALLOY=true ;;
+        --install-mise) INSTALL_MISE=true ;;
+        --install-go-task) INSTALL_GO_TASK=true ;;
+        --install-claude) INSTALL_CLAUDE=true ;;
         *)
             echo "Unknown option: $1"
             echo "Usage: $0 [--skip-ansible] [--install-alloy] [--install-mise] [--install-go-task] [--install-claude]"
             exit 1
             ;;
     esac
+    shift
 done
-
 
 INSTALL_DIR="$(pwd)"
 ANSIBLE_DIR="$HOME/cowdogmoo/ansible-collection-workstation"
@@ -89,15 +74,25 @@ setup_ansible() {
         echo -e "${YELLOW}Using existing ansible workstation repo...${RESET}"
     fi
 
-    echo "Installing CowDogMoo workstation collection..."
-    ansible-galaxy collection install git+https://github.com/CowDogMoo/ansible-collection-workstation.git,main --upgrade
+    echo "Installing CowDogMoo workstation collection and dependencies..."
+    local install_ok=true
+    ansible-galaxy collection install git+https://github.com/CowDogMoo/ansible-collection-workstation.git,main --upgrade || install_ok=false
+    # The playbook statically imports grafana.grafana.alloy, so its collection
+    # must be present for the play to parse even when the role is skipped.
+    if [[ -f "${ANSIBLE_DIR}/requirements.yml" ]]; then
+        ansible-galaxy collection install -r "${ANSIBLE_DIR}/requirements.yml" --upgrade || install_ok=false
+    fi
 
-    # Only install heavy dependencies if requested
-    if [[ "${INSTALL_ALLOY}" == true ]]; then
-        echo "Installing collection dependencies for Alloy..."
-        if [[ -f "${ANSIBLE_DIR}/requirements.yml" ]]; then
-            ansible-galaxy collection install -r "${ANSIBLE_DIR}/requirements.yml" --upgrade
+    if [[ "${install_ok}" == false ]]; then
+        # Tolerate upgrade failures (e.g. offline) when the collections exist.
+        local installed
+        installed=$(ansible-galaxy collection list 2> /dev/null)
+        if ! grep -q "cowdogmoo.workstation" <<< "${installed}" \
+            || ! grep -q "grafana.grafana" <<< "${installed}"; then
+            echo "Failed to install required Ansible collections." >&2
+            exit 1
         fi
+        echo -e "${YELLOW}Collection upgrade failed; using existing installed collections.${RESET}"
     fi
 
     local hostname
@@ -108,31 +103,31 @@ setup_ansible() {
 ${hostname} ansible_connection=local
 EOF
 
+    # Opt-in roles: skip each playbook tag unless its --install-* flag was set.
     local skip_tags=()
-    if [[ "${INSTALL_ALLOY}" == false ]]; then
-        skip_tags+=("alloy")
-    fi
-    if [[ "${INSTALL_MISE}" == false ]]; then
-        skip_tags+=("mise")
-    fi
-    if [[ "${INSTALL_GO_TASK}" == false ]]; then
-        skip_tags+=("go_task")
-    fi
-    if [[ "${INSTALL_CLAUDE}" == false ]]; then
-        skip_tags+=("claude")
-    fi
+    local entry
+    for entry in "alloy:${INSTALL_ALLOY}" "mise:${INSTALL_MISE}" \
+        "go_task:${INSTALL_GO_TASK}" "claude:${INSTALL_CLAUDE}"; do
+        if [[ "${entry#*:}" == false ]]; then
+            skip_tags+=("${entry%%:*}")
+        fi
+    done
 
     local extra_args=()
     if [[ ${#skip_tags[@]} -gt 0 ]]; then
-        # Join tags with commas
-        local joined_tags=$(IFS=,; echo "${skip_tags[*]}")
+        local joined_tags
+        joined_tags=$(
+            IFS=,
+            echo "${skip_tags[*]}"
+        )
         extra_args+=("--skip-tags" "${joined_tags}")
     fi
 
+    # ${arr[@]+...} keeps the empty-array expansion safe under set -u on bash 3.2.
     ansible-playbook "${ANSIBLE_DIR}/playbooks/workstation/workstation.yml" \
         -i "${inventory_file}" \
         -e "shell_functions_source_path=${INSTALL_DIR}" \
-        "${extra_args[@]}"
+        ${extra_args[@]+"${extra_args[@]}"}
 }
 
 ### MAIN ###

--- a/install_dot_files.sh
+++ b/install_dot_files.sh
@@ -7,26 +7,55 @@
 # ~/.zshrc, ~/.tmux.conf, ~/.gitconfig, ~/.ansible.cfg, the vault-pass helper,
 # and the deployment of shell-function libraries into ~/.dotfiles.
 #
-# Usage: bash install_dot_files.sh [--skip-ansible]
+# Usage: bash install_dot_files.sh [options]
+#
+# Options:
+#   --skip-ansible     Skip the entire Ansible setup.
+#   --install-alloy    Install and configure Grafana Alloy (requires Node).
+#   --install-mise     Install and configure Mise tool manager.
+#   --install-go-task  Install and configure Go Task.
+#   --install-claude   Install and configure Claude Code CLI (requires Node).
 #
 # Jayson Grace <jayson.e.grace at gmail.com>
 # -----------------------------------------------------------------------------
 set -eou pipefail
 
 RUN_ANSIBLE=true
+INSTALL_ALLOY=false
+INSTALL_MISE=false
+INSTALL_GO_TASK=false
+INSTALL_CLAUDE=false
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         --skip-ansible)
             RUN_ANSIBLE=false
             shift
             ;;
+        --install-alloy)
+            INSTALL_ALLOY=true
+            shift
+            ;;
+        --install-mise)
+            INSTALL_MISE=true
+            shift
+            ;;
+        --install-go-task)
+            INSTALL_GO_TASK=true
+            shift
+            ;;
+        --install-claude)
+            INSTALL_CLAUDE=true
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--skip-ansible]"
+            echo "Usage: $0 [--skip-ansible] [--install-alloy] [--install-mise] [--install-go-task] [--install-claude]"
             exit 1
             ;;
     esac
 done
+
 
 INSTALL_DIR="$(pwd)"
 ANSIBLE_DIR="$HOME/cowdogmoo/ansible-collection-workstation"
@@ -39,6 +68,14 @@ YELLOW="\033[01;33m"
 setup_ansible() {
     echo "Setting up Ansible environment..."
 
+    if [[ "$(uname)" == "Darwin" ]]; then
+        if [[ -f "/opt/homebrew/bin/brew" ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [[ -f "/usr/local/bin/brew" ]]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    fi
+
     if ! command -v ansible-galaxy &> /dev/null; then
         echo "Ansible is not installed. Please install it first."
         exit 1
@@ -48,11 +85,19 @@ setup_ansible() {
         echo -e "${YELLOW}Cloning ansible workstation repo...${RESET}"
         mkdir -p "$(dirname "${ANSIBLE_DIR}")"
         git clone https://github.com/CowDogMoo/ansible-collection-workstation.git "${ANSIBLE_DIR}"
+    else
+        echo -e "${YELLOW}Using existing ansible workstation repo...${RESET}"
     fi
 
-    if ! ansible-galaxy collection list 2> /dev/null | grep -q "cowdogmoo.workstation"; then
-        echo "Installing CowDogMoo workstation collection..."
-        ansible-galaxy collection install git+https://github.com/CowDogMoo/ansible-collection-workstation.git,main
+    echo "Installing CowDogMoo workstation collection..."
+    ansible-galaxy collection install git+https://github.com/CowDogMoo/ansible-collection-workstation.git,main --upgrade
+
+    # Only install heavy dependencies if requested
+    if [[ "${INSTALL_ALLOY}" == true ]]; then
+        echo "Installing collection dependencies for Alloy..."
+        if [[ -f "${ANSIBLE_DIR}/requirements.yml" ]]; then
+            ansible-galaxy collection install -r "${ANSIBLE_DIR}/requirements.yml" --upgrade
+        fi
     fi
 
     local hostname
@@ -63,9 +108,31 @@ setup_ansible() {
 ${hostname} ansible_connection=local
 EOF
 
+    local skip_tags=()
+    if [[ "${INSTALL_ALLOY}" == false ]]; then
+        skip_tags+=("alloy")
+    fi
+    if [[ "${INSTALL_MISE}" == false ]]; then
+        skip_tags+=("mise")
+    fi
+    if [[ "${INSTALL_GO_TASK}" == false ]]; then
+        skip_tags+=("go_task")
+    fi
+    if [[ "${INSTALL_CLAUDE}" == false ]]; then
+        skip_tags+=("claude")
+    fi
+
+    local extra_args=()
+    if [[ ${#skip_tags[@]} -gt 0 ]]; then
+        # Join tags with commas
+        local joined_tags=$(IFS=,; echo "${skip_tags[*]}")
+        extra_args+=("--skip-tags" "${joined_tags}")
+    fi
+
     ansible-playbook "${ANSIBLE_DIR}/playbooks/workstation/workstation.yml" \
         -i "${inventory_file}" \
-        -e "shell_functions_source_path=${INSTALL_DIR}"
+        -e "shell_functions_source_path=${INSTALL_DIR}" \
+        "${extra_args[@]}"
 }
 
 ### MAIN ###


### PR DESCRIPTION
**Key Changes:**

- Introduced opt-in install flags with tag-based role selection in Ansible
- Hardened Ansible collection installs with upgrades, dependency handling, and offline tolerance
- Bootstrapped Homebrew environment on macOS to ensure Ansible tools are on PATH
- Updated Go helper to use new config path and removed noisy cowsay banner

**Added:**

- Opt-in role installation for workstation setup - Added flags --install-alloy, --install-mise, --install-go-task, and --install-claude; roles are skipped by default via computed --skip-tags passed to ansible-playbook, ensuring only explicitly requested components are installed (install_dot_files.sh)
- macOS Homebrew environment bootstrap - Detect and eval brew shellenv from /opt/homebrew or /usr/local to expose Ansible and dependencies in PATH before running galaxy or playbooks (install_dot_files.sh)

**Changed:**

- Ansible collection installation strategy - Always run ansible-galaxy collection install with --upgrade for cowdogmoo.workstation and, when present, install dependencies from requirements.yml; tolerate upgrade failures when required collections already exist, and explicitly ensure grafana.grafana is installed due to static import so the playbook parses even if roles are skipped (install_dot_files.sh)
- CLI usage and argument parsing - Expanded usage to include new flags, simplified option parsing (single shift per loop), and improved unknown option handling to print full usage (install_dot_files.sh)
- Default config path for Go script - Switched FILES from ~/.dotfiles/files to ~/.dotfiles/config to align with current layout (go.sh)

**Removed:**

- Cowsay banner on shell startup - Dropped random cowsay output gated on cowsay/gshuf to reduce noise and avoid incidental dependencies (bashutils.sh)