### PR TITLE
chore: update renovate configuration for broader automerge coverage

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "suppressNotifications": ["prIgnoreNotification"],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "auto",
   "commitBodyTable": true,
   "pre-commit": {
     "enabled": true
@@ -24,7 +24,7 @@
       "matchDatasources": ["github-tags"],
       "automerge": true,
       "automergeType": "pr",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["major", "minor", "patch"]
     },
     {
       "description": "Group shell script dependencies",
@@ -56,7 +56,7 @@
       "matchManagers": ["pre-commit"],
       "automerge": true,
       "automergeType": "pr",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["major", "minor", "patch"]
     }
   ],
   "npm": {


### PR DESCRIPTION
**Key Changes:**

- Changed rebase strategy from `conflicted` to `auto` for more proactive PR rebasing
- Expanded automerge rules to include major version updates for github-tags and pre-commit dependencies

**Changed:**

- Rebase behavior - Updated `rebaseWhen` from `"conflicted"` to `"auto"` so Renovate will rebase PRs automatically rather than only when conflicts arise
- Automerge version scope - Extended `matchUpdateTypes` to include `"major"` updates (in addition to `minor` and `patch`) for both github-tags and pre-commit manager rules, allowing major version bumps to be automerged without manual intervention