### PR TITLE
fix: prevent empty commit messages when fabric generation fails

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -54,7 +54,15 @@ check_fabric() {
 #   Requires git alias 'ds' and the fabric tool to be installed.
 fabric_commit() {
     check_fabric || return 1
-    git ds | fabric --pattern commit | ~/.config/fabric/patterns/commit/filter.sh | git commit --cleanup=verbatim -F - && git push
+    local msg
+    msg=$(git ds | fabric --pattern commit | ~/.config/fabric/patterns/commit/filter.sh)
+    # git commit --cleanup=verbatim -F - accepts empty stdin, so a failed fabric
+    # call (dead API key, no credits) would otherwise create a message-less commit.
+    if [ -z "$(printf '%s' "$msg" | tr -d '[:space:]')" ]; then
+        echo "error: commit message is empty — fabric call failed; check 'git ds | fabric --pattern commit'" >&2
+        return 1
+    fi
+    printf '%s\n' "$msg" | git commit --cleanup=verbatim -F - && git push
 }
 
 # fabric_pr() generates a PR title/body using fabric AI and creates or updates


### PR DESCRIPTION
**Key Changes:**

- Guard against empty commit messages by verifying fabric output and aborting
- Capture AI-generated message into a variable for validation before commit
- Emit a clear stderr error with guidance to check the fabric command and exit non-zero
- Only commit and push when a non-empty message is present

**Changed:**

- Improve commit flow robustness in fabric_commit by capturing the fabric-generated message, trimming whitespace to detect emptiness, and aborting with a helpful error if generation fails (avoiding message-less commits since git commit -F - accepts empty stdin). Proceed to commit/push only when the message is non-empty - git.sh