### PR TITLE
style: standardize github labeler yaml list formatting

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -28,10 +28,9 @@ area/templates:
 # Cloud
 area/aws:
   - changed-files:
-      - any-glob-to-any-file: [
-          "aws",
-          "cloud/aws/**/*"
-        ]
+      - any-glob-to-any-file:
+          - "aws"
+          - "cloud/aws/**/*"
 area/gcloud:
   - changed-files:
       - any-glob-to-any-file: "gcloud"
@@ -59,10 +58,9 @@ area/common:
       - any-glob-to-any-file: "common"
 area/containers:
   - changed-files:
-      - any-glob-to-any-file: [
-          "containers",
-          "docker"
-        ]
+      - any-glob-to-any-file:
+          - "containers"
+          - "docker"
 area/k8s:
   - changed-files:
       - any-glob-to-any-file: "k8s"
@@ -84,9 +82,7 @@ area/macos:
 # Configuration
 area/dotfiles:
   - changed-files:
-      - any-glob-to-any-file: [
-          "install_dotfiles.sh"
-        ]
+      - any-glob-to-any-file: "install_dotfiles.sh"
 
 # Style
 area/style:


### PR DESCRIPTION
**Key Changes:**

- Converted inline arrays to block sequences for multi-pattern globs in aws and containers
- Simplified single-item arrays to scalars where appropriate to reduce noise
- Improved readability and consistency of labeler config without changing behavior

**Changed:**

- Labeler config formatting - Replaced inline arrays with block lists for any-glob-to-any-file in area/aws and area/containers; reduced a single-item list to a scalar in area/dotfiles; aligned YAML structure for consistency and clearer diffs in .github/labeler.yaml