### PR TITLE
ci: pin ansible-galaxy collections and configure renovate regex manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,6 +89,19 @@
         "^(?<depName>[^ ]+) (?<currentValue>[^ ]+)$"
       ],
       "datasourceTemplate": "rubygems"
+    },
+    {
+      // ansible-galaxy takes the git ref inline, so no manager recognizes these.
+      // Tracking the branch tip by digest keeps CI reproducible while still surfacing
+      // upstream movement as a reviewable PR instead of a surprise red build.
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/tests\\.yaml$"],
+      "matchStrings": [
+        "ansible-galaxy collection install git\\+https://github\\.com/(?<depName>[^,\\s]+?)\\.git,(?<currentDigest>[0-9a-f]{40})"
+      ],
+      "packageNameTemplate": "https://github.com/{{{depName}}}",
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs"
     }
   ],
   "ignorePaths": [

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,8 +46,10 @@ jobs:
               brew install curl git zsh python3 ansible
           fi
 
+      # Pinned to a commit rather than main: an unrelated merge upstream would otherwise
+      # turn this workflow red with no change on our side. Renovate bumps the digests.
       - name: Install workstation collection
-        run: ansible-galaxy collection install git+https://github.com/cowdogmoo/workstation.git,main
+        run: ansible-galaxy collection install git+https://github.com/cowdogmoo/workstation.git,bc6c9c8ecf3071e0f38fd869d244345018103660
 
       - name: Install the dotfiles
         run: |
@@ -119,10 +121,12 @@ jobs:
               brew install curl git zsh python3 ansible
           fi
 
+      # Pinned to commits rather than main: an unrelated merge upstream would otherwise
+      # turn this workflow red with no change on our side. Renovate bumps the digests.
       - name: Install the necessary ansible collections
         run: |
-          ansible-galaxy collection install git+https://github.com/cowdogmoo/workstation.git,main
-          ansible-galaxy collection install git+https://github.com/grafana/grafana-ansible-collection.git,main
+          ansible-galaxy collection install git+https://github.com/cowdogmoo/workstation.git,bc6c9c8ecf3071e0f38fd869d244345018103660
+          ansible-galaxy collection install git+https://github.com/grafana/grafana-ansible-collection.git,521b006dabf4f605e9663c6539bfdec653badb1b
 
       - name: Install the dotfiles
         env:


### PR DESCRIPTION
**Key Changes:**

- Pin ansible-galaxy installs in CI to specific commit SHAs for reproducible builds
- Add Renovate regex manager to detect and auto-bump pinned ansible-galaxy digests
- Document rationale in workflow to prevent red builds from unrelated upstream merges

**Added:**

- Renovate regex manager for ansible-galaxy git+ installs in tests workflow - .github/renovate.json5; matches inline GitHub refs in tests.yaml, captures depName and a 40-char digest, maps to https://github.com/<dep>, tracks main via git-refs, and opens PRs when upstream tips move to keep CI stable and reviewable

**Changed:**

- CI workflow now pins ansible collections by commit SHA instead of main - .github/workflows/tests.yaml; workstation collection pinned in the macOS setup step (bc6c9c8ecf3071e0f38fd869d244345018103660) and both workstation and grafana collections pinned in the Linux setup step (bc6c9c8ecf3071e0f38fd869d244345018103660 and 521b006dabf4f605e9663c6539bfdec653badb1b), with comments explaining the approach and relying on Renovate to bump digests automatically