### PR TITLE
fix: diff fabric_pr against origin base branch and strengthen tests

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -133,10 +133,11 @@ fabric_pr() {
     local base remote
     base=$(gh pr view --json baseRefName --jq '.baseRefName' 2> /dev/null)
     : "${base:=main}"
-    # Diff against the base branch on the remote the PR will live in, which is
-    # the fork rather than origin when working from one.
-    remote=$(git_push_remote)
-    pr_text=$(git diff "${remote}/${base}...HEAD" | fabric --pattern pr | ~/.config/fabric/patterns/pr/filter.sh)
+    # Diff against origin's copy of the base branch, not the push remote's. The PR is
+    # opened against origin, and baseRefName names a branch there; a fork's own copy is
+    # usually stale and often never fetched, which would either pad the diff with commits
+    # the PR does not contain or abort on an unknown revision.
+    pr_text=$(git diff "origin/${base}...HEAD" | fabric --pattern pr | ~/.config/fabric/patterns/pr/filter.sh)
     if [ -z "$pr_text" ]; then
         echo "error: PR text is empty"
         return 1
@@ -163,6 +164,7 @@ fabric_pr() {
 
     # Push the branch. After a rebase/amend the remote has diverged, so fall
     # back to --force-with-lease (refuses if the remote moved unexpectedly).
+    remote=$(git_push_remote)
     if ! git push -u "$remote" HEAD 2> /dev/null; then
         if ! git push --force-with-lease -u "$remote" HEAD; then
             echo "error: Failed to push branch"

--- a/tests/test-git.bats
+++ b/tests/test-git.bats
@@ -457,26 +457,43 @@ teardown() {
 
 # fabric_commit tests
 
-# Stubs the fabric commit filter under a throwaway HOME and mocks the commands
-# fabric_commit shells out to, so it can run without touching the real repo.
-# $1 is the message fabric should emit. Every git invocation is appended to
-# $GIT_LOG so tests can assert on what was (and was not) run.
-stub_fabric_commit() {
-	export FABRIC_MSG="$1"
+# Stubs a fabric pattern filter under a throwaway HOME and mocks every command the
+# fabric_* helpers shell out to, so they can run without touching the real repo or
+# GitHub. $1 is the pattern directory (commit or pr), $2 the text fabric should emit.
+# Each git and gh invocation is appended to $GIT_LOG / $GH_LOG so tests can assert on
+# what was (and was not) run.
+stub_fabric() {
+	export FABRIC_MSG="$2"
 	export HOME="$BATS_TEST_TMPDIR/home"
 	export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+	export GH_LOG="$BATS_TEST_TMPDIR/gh.log"
 
-	mkdir -p "$HOME/.config/fabric/patterns/commit"
-	printf '#!/usr/bin/env bash\ncat\n' > "$HOME/.config/fabric/patterns/commit/filter.sh"
-	chmod +x "$HOME/.config/fabric/patterns/commit/filter.sh"
+	mkdir -p "$HOME/.config/fabric/patterns/$1"
+	printf '#!/usr/bin/env bash\ncat\n' > "$HOME/.config/fabric/patterns/$1/filter.sh"
+	chmod +x "$HOME/.config/fabric/patterns/$1/filter.sh"
 	: > "$GIT_LOG"
+	: > "$GH_LOG"
 
 	check_fabric() { return 0; }
-	fabric() { printf '%s' "$FABRIC_MSG"; }
+	fabric() {
+		cat > /dev/null
+		printf '%s' "$FABRIC_MSG"
+	}
+	gh() {
+		echo "gh $*" >> "$GH_LOG"
+		case "$*" in
+			"repo view"*) printf '%s\n' "l50/dotfiles" ;;
+			"pr view"*baseRefName*) printf '%s\n' "main" ;;
+			# No existing PR, so fabric_pr takes the create path.
+			"pr view"*) return 1 ;;
+			"pr create"*) printf '%s\n' "https://github.com/l50/dotfiles/pull/1" ;;
+		esac
+		return 0
+	}
 	git() {
 		echo "git $*" >> "$GIT_LOG"
 		case "$1" in
-			ds) printf 'diff --git a/x b/x\n' ;;
+			ds | diff) printf 'diff --git a/x b/x\n' ;;
 			commit) cat > /dev/null ;;
 			branch) printf '%s\n' "topic" ;;
 			config)
@@ -488,8 +505,19 @@ stub_fabric_commit() {
 		esac
 		return 0
 	}
-	export -f check_fabric fabric git
+	export -f check_fabric fabric gh git
 }
+
+stub_fabric_commit() { stub_fabric commit "$1"; }
+
+stub_fabric_pr() { stub_fabric pr "$1"; }
+
+# Point the mocked git config at a branch pushRemote / remote.pushDefault of $1, so
+# git_push_remote resolves to it. Wrapped in functions because a bare export inside a
+# @test reads as a subshell-local modification to shellcheck.
+stub_branch_push_remote() { export STUB_BRANCH_PUSH_REMOTE="$1"; }
+
+stub_push_default() { export STUB_PUSH_DEFAULT="$1"; }
 
 @test "fabric_commit aborts without committing when fabric returns an empty message" {
 	stub_fabric_commit "   "
@@ -517,7 +545,7 @@ stub_fabric_commit() {
 @test "fabric_commit pushes to the branch's pushRemote instead of origin" {
 	stub_fabric_commit "fix: correct the thing"
 	# In a fork, origin is the read-only upstream and pushing there 403s.
-	export STUB_BRANCH_PUSH_REMOTE="fork"
+	stub_branch_push_remote fork
 
 	run fabric_commit
 
@@ -528,10 +556,28 @@ stub_fabric_commit() {
 
 @test "fabric_commit falls back to remote.pushDefault when no branch pushRemote" {
 	stub_fabric_commit "fix: correct the thing"
-	export STUB_PUSH_DEFAULT="fork"
+	stub_push_default fork
 
 	run fabric_commit
 
 	assert_success
+	assert grep -q "git push -u fork HEAD" "$GIT_LOG"
+}
+
+@test "fabric_pr diffs against origin's base branch even when pushing elsewhere" {
+	stub_fabric_pr "feat: add a thing
+
+Body of the PR."
+	stub_branch_push_remote fork
+
+	run fabric_pr
+
+	assert_success
+	# The PR is opened against origin and baseRefName names a branch there, so the diff
+	# base stays origin/<base>. A fork's own copy is usually stale and often unfetched,
+	# which would pad the diff or abort on an unknown revision.
+	assert grep -q "git diff origin/main\.\.\.HEAD" "$GIT_LOG"
+	refute grep -q "git diff fork/main" "$GIT_LOG"
+	# The push still honours the configured remote.
 	assert grep -q "git push -u fork HEAD" "$GIT_LOG"
 }


### PR DESCRIPTION
**Key Changes:**

- Compute PR diffs against origin/<base> to match the PR target and avoid stale fork refs
- Add gh-aware test stubs and a new test validating diff base and push behavior
- Re-evaluate push remote right before pushing to honor branch pushRemote/pushDefault
- Refactor test helpers into a generic fabric stub supporting commit and pr flows

**Added:**

- Generalized test stub for fabric and gh - Introduced stub_fabric that stubs the chosen pattern directory (commit or pr), consumes stdin, emits the provided message, mocks gh commands, and captures both git and gh invocations (GIT_LOG/GH_LOG) - tests/test-git.bats
- Helper wrappers for clarity and shellcheck - Added stub_fabric_pr, stub_branch_push_remote, and stub_push_default to make tests more explicit and avoid subshell export issues - tests/test-git.bats
- Validation of PR diff base - New test ensures fabric_pr diffs against origin’s base branch while still pushing to the configured remote - tests/test-git.bats

**Changed:**

- PR diff base selection - fabric_pr now diffs against origin/<baseRefName> instead of the push remote’s copy of the base; this matches the actual PR target and prevents padded diffs from stale forks or failures on unfetched refs - git.sh
- Push behavior robustness - fabric_pr now resolves the push remote immediately before pushing (via git_push_remote) to correctly honor branch pushRemote or remote.pushDefault after rebases/amends - git.sh
- Test harness behavior - fabric stub now reads and discards stdin before outputting the message; git stub handles both ds and diff; existing tests updated to use wrapper helpers and improved stubs - tests/test-git.bats