### PR TITLE
fix: diff PRs against target repo's base branch with origin fallback

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -64,6 +64,40 @@ git_push_remote() {
     printf '%s\n' "${remote:-origin}"
 }
 
+# git_remote_for_repo() prints the local remote whose URL points at the given
+# GitHub <owner>/<name>, defaulting to origin when nothing matches.
+#
+# Usage:
+#   git_remote_for_repo l50/dotfiles
+#
+# Output:
+#   A remote name, defaulting to "origin".
+#
+# Example:
+#   git diff "$(git_remote_for_repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)")/main...HEAD"
+#
+# Note:
+#   Used to pick a diff base matching the repo a PR is opened against. That is normally
+#   origin, but "gh repo set-default" can aim PRs at a fork instead, in which case
+#   origin's copy of the base branch is the stale one.
+git_remote_for_repo() {
+    local repo=$1 remote url
+    if [ -n "$repo" ]; then
+        # Remote names cannot contain whitespace, so word splitting is safe here.
+        # shellcheck disable=SC2013
+        for remote in $(git remote); do
+            url=$(git remote get-url "$remote" 2> /dev/null) || continue
+            case "${url%.git}" in
+                *[:/]"$repo")
+                    printf '%s\n' "$remote"
+                    return
+                    ;;
+            esac
+        done
+    fi
+    printf '%s\n' "origin"
+}
+
 # fabric_commit() generates a commit message using fabric AI and commits
 # the staged changes, then pushes to remote.
 #
@@ -130,14 +164,19 @@ fabric_pr() {
     echo "⏺ Generating PR with Fabric AI..."
     echo
 
-    local base remote
+    local base remote base_remote
     base=$(gh pr view --json baseRefName --jq '.baseRefName' 2> /dev/null)
     : "${base:=main}"
-    # Diff against origin's copy of the base branch, not the push remote's. The PR is
-    # opened against origin, and baseRefName names a branch there; a fork's own copy is
-    # usually stale and often never fetched, which would either pad the diff with commits
-    # the PR does not contain or abort on an unknown revision.
-    pr_text=$(git diff "origin/${base}...HEAD" | fabric --pattern pr | ~/.config/fabric/patterns/pr/filter.sh)
+    # Diff against the base branch as it exists in the repo the PR is opened against, not
+    # the push remote's copy. That repo is usually origin, but "gh repo set-default" can
+    # aim PRs at a fork, and then origin is the stale one and would pad the diff with
+    # commits the PR does not contain. Fall back to origin when the resolved remote's copy
+    # was never fetched, since a missing revision aborts the diff outright.
+    base_remote=$(git_remote_for_repo "$repo")
+    if ! git rev-parse --verify --quiet "${base_remote}/${base}" > /dev/null 2>&1; then
+        base_remote=origin
+    fi
+    pr_text=$(git diff "${base_remote}/${base}...HEAD" | fabric --pattern pr | ~/.config/fabric/patterns/pr/filter.sh)
     if [ -z "$pr_text" ]; then
         echo "error: PR text is empty"
         return 1

--- a/tests/test-git.bats
+++ b/tests/test-git.bats
@@ -492,10 +492,34 @@ stub_fabric() {
 	}
 	git() {
 		echo "git $*" >> "$GIT_LOG"
+		local entry
 		case "$1" in
 			ds | diff) printf 'diff --git a/x b/x\n' ;;
 			commit) cat > /dev/null ;;
 			branch) printf '%s\n' "topic" ;;
+			# STUB_REMOTES is a space-separated list of <name>=<url> pairs, so a test can
+			# describe a fork layout without creating real remotes.
+			remote)
+				if [[ "$2" == "get-url" ]]; then
+					for entry in ${STUB_REMOTES:-}; do
+						if [[ "${entry%%=*}" == "$3" ]]; then
+							printf '%s\n' "${entry#*=}"
+							return 0
+						fi
+					done
+					return 1
+				fi
+				for entry in ${STUB_REMOTES:-}; do
+					printf '%s\n' "${entry%%=*}"
+				done
+				;;
+			# git rev-parse --verify --quiet <ref>, so the ref is $4. Refs named in
+			# STUB_MISSING_REFS stand in for a remote branch that was never fetched.
+			rev-parse)
+				case " ${STUB_MISSING_REFS:-} " in
+					*" $4 "*) return 1 ;;
+				esac
+				;;
 			config)
 				case "$*" in
 					*pushRemote) printf '%s' "${STUB_BRANCH_PUSH_REMOTE:-}" ;;
@@ -518,6 +542,13 @@ stub_fabric_pr() { stub_fabric pr "$1"; }
 stub_branch_push_remote() { export STUB_BRANCH_PUSH_REMOTE="$1"; }
 
 stub_push_default() { export STUB_PUSH_DEFAULT="$1"; }
+
+# Describe the repo's remotes as "<name>=<url>" pairs, so git_remote_for_repo can map
+# gh's base repo onto one of them.
+stub_remotes() { export STUB_REMOTES="$*"; }
+
+# Mark remote-tracking refs as never fetched, so rev-parse --verify fails on them.
+stub_missing_refs() { export STUB_MISSING_REFS="$*"; }
 
 @test "fabric_commit aborts without committing when fabric returns an empty message" {
 	stub_fabric_commit "   "
@@ -580,4 +611,60 @@ Body of the PR."
 	refute grep -q "git diff fork/main" "$GIT_LOG"
 	# The push still honours the configured remote.
 	assert grep -q "git push -u fork HEAD" "$GIT_LOG"
+}
+
+@test "fabric_pr diffs against the fork when gh opens PRs there" {
+	stub_fabric_pr "feat: add a thing
+
+Body of the PR."
+	stub_branch_push_remote fork
+	# "gh repo set-default" can aim PRs at the fork, which is what the stubbed
+	# "gh repo view" reports. Then origin is the stale copy, and diffing it would pad
+	# the PR body with commits the PR does not contain.
+	stub_remotes "origin=https://github.com/upstream/dotfiles.git" \
+		"fork=https://github.com/l50/dotfiles.git"
+
+	run fabric_pr
+
+	assert_success
+	assert grep -q "git diff fork/main\.\.\.HEAD" "$GIT_LOG"
+	refute grep -q "git diff origin/main" "$GIT_LOG"
+}
+
+@test "fabric_pr falls back to origin when the base repo's remote branch is unfetched" {
+	stub_fabric_pr "feat: add a thing
+
+Body of the PR."
+	stub_remotes "origin=https://github.com/upstream/dotfiles.git" \
+		"fork=https://github.com/l50/dotfiles.git"
+	# A missing revision aborts the diff outright, so a never-fetched fork branch has to
+	# degrade to origin rather than take the whole PR down.
+	stub_missing_refs "fork/main"
+
+	run fabric_pr
+
+	assert_success
+	assert grep -q "git diff origin/main\.\.\.HEAD" "$GIT_LOG"
+	refute grep -q "git diff fork/main" "$GIT_LOG"
+}
+
+@test "git_remote_for_repo falls back to origin when no remote matches" {
+	stub_fabric_pr "unused"
+	stub_remotes "origin=https://github.com/upstream/dotfiles.git"
+
+	run git_remote_for_repo "l50/dotfiles"
+
+	assert_success
+	assert_output "origin"
+}
+
+@test "git_remote_for_repo matches an ssh remote URL" {
+	stub_fabric_pr "unused"
+	stub_remotes "origin=https://github.com/upstream/dotfiles.git" \
+		"fork=git@github.com:l50/dotfiles.git"
+
+	run git_remote_for_repo "l50/dotfiles"
+
+	assert_success
+	assert_output "fork"
 }


### PR DESCRIPTION
**Key Changes:**

- Resolve PR diffs against the base branch in the repo the PR targets, not the push remote
- Introduce git_remote_for_repo to map a GitHub owner/name to a local remote with sensible defaults
- Fallback to origin when the target remote’s base branch was never fetched to avoid diff failures
- Expand test stubs and add coverage for fork targeting, fallback behavior, and URL matching

**Added:**

- Remote resolution helper - Implemented git_remote_for_repo to find the local remote that points to a given GitHub <owner>/<name>, handling HTTPS/SSH URLs and defaulting to origin when no match is found - git.sh
- Test utilities - Added stub_remotes to describe remotes and stub_missing_refs to simulate unfetched remote-tracking refs, enabling precise test scenarios - tests/test-git.bats
- Test coverage for remote resolution and fallback - Added tests verifying:
  - fabric_pr diffs against a fork when gh opens PRs there
  - fabric_pr falls back to origin when the target remote’s base branch is unfetched
  - git_remote_for_repo defaults to origin with no matches
  - git_remote_for_repo matches SSH remote URLs - tests/test-git.bats

**Changed:**

- PR diff base selection - fabric_pr now determines the correct base remote via git_remote_for_repo using gh’s target repo, verifies the remote ref exists with git rev-parse, falls back to origin when missing, and diffs against "${base_remote}/${base}...HEAD" to avoid padding PRs with unrelated commits from stale remotes - git.sh
- Git command stubs for tests - Extended the git() stub to emulate remote enumeration/get-url and rev-parse --verify behavior, enabling robust testing of remote mapping and unfetched ref handling - tests/test-git.bats