### PR TITLE
fix: refresh base branch before generating PR diff

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -176,6 +176,16 @@ fabric_pr() {
     if ! git rev-parse --verify --quiet "${base_remote}/${base}" > /dev/null 2>&1; then
         base_remote=origin
     fi
+    # Refresh the base before diffing. Remote-tracking refs only move when that
+    # branch is fetched, and fetching a feature branch does not touch them, so
+    # the local copy of the base drifts behind without any visible signal. A
+    # stale base pads the diff with commits already merged upstream and fabric
+    # then writes a PR describing someone else's work. Non-fatal so the command
+    # still works offline, but warn, since the result is silently wrong.
+    if ! git fetch --quiet "$base_remote" "$base" 2> /dev/null; then
+        echo "warning: could not refresh ${base_remote}/${base} — diff may include already-merged commits"
+        echo
+    fi
     pr_text=$(git diff "${base_remote}/${base}...HEAD" | fabric --pattern pr | ~/.config/fabric/patterns/pr/filter.sh)
     if [ -z "$pr_text" ]; then
         echo "error: PR text is empty"

--- a/tests/test-git.bats
+++ b/tests/test-git.bats
@@ -526,6 +526,9 @@ stub_fabric() {
 					*remote.pushDefault) printf '%s' "${STUB_PUSH_DEFAULT:-}" ;;
 				esac
 				;;
+			# A failing fetch stands in for an offline run, where the base cannot be
+			# refreshed but the stale copy is still diffable.
+			fetch) return "${STUB_FETCH_STATUS:-0}" ;;
 		esac
 		return 0
 	}
@@ -549,6 +552,9 @@ stub_remotes() { export STUB_REMOTES="$*"; }
 
 # Mark remote-tracking refs as never fetched, so rev-parse --verify fails on them.
 stub_missing_refs() { export STUB_MISSING_REFS="$*"; }
+
+# Make "git fetch" fail, so the base branch cannot be refreshed.
+stub_failing_fetch() { export STUB_FETCH_STATUS=1; }
 
 @test "fabric_commit aborts without committing when fabric returns an empty message" {
 	stub_fabric_commit "   "
@@ -646,6 +652,39 @@ Body of the PR."
 	assert_success
 	assert grep -q "git diff origin/main\.\.\.HEAD" "$GIT_LOG"
 	refute grep -q "git diff fork/main" "$GIT_LOG"
+}
+
+@test "fabric_pr refreshes the base branch it diffs against" {
+	stub_fabric_pr "feat: add a thing
+
+Body of the PR."
+	stub_remotes "origin=https://github.com/upstream/dotfiles.git" \
+		"fork=https://github.com/l50/dotfiles.git"
+
+	run fabric_pr
+
+	assert_success
+	# Pushing a feature branch never moves the base's remote-tracking ref, so without
+	# this fetch the diff replays commits already merged upstream. It has to target the
+	# same remote the diff uses, or the refresh lands on a ref nothing reads.
+	assert grep -q "git fetch --quiet fork main" "$GIT_LOG"
+	assert grep -q "git diff fork/main\.\.\.HEAD" "$GIT_LOG"
+}
+
+@test "fabric_pr warns but still opens the PR when the base cannot be refreshed" {
+	stub_fabric_pr "feat: add a thing
+
+Body of the PR."
+	# Offline, the stale base is still diffable, so a failed refresh degrades to a
+	# warning instead of taking the PR down.
+	stub_failing_fetch
+
+	run fabric_pr
+
+	assert_success
+	assert_output --partial "could not refresh origin/main"
+	assert grep -q "git diff origin/main\.\.\.HEAD" "$GIT_LOG"
+	assert grep -q "gh pr create" "$GH_LOG"
 }
 
 @test "git_remote_for_repo falls back to origin when no remote matches" {


### PR DESCRIPTION
**Key Changes:**

- Added a `git fetch` of the base branch before diffing to prevent stale remote-tracking refs from padding the PR diff with already-merged commits
- Made the refresh non-fatal so PR generation still works offline, degrading to a warning instead of failing
- Added test coverage for both the successful refresh and the offline warning path

**Added:**

- Base branch refresh in `fabric_pr` - Added a `git fetch --quiet "$base_remote" "$base"` call before the diff in `git.sh`, targeting the same remote the diff uses so the refresh lands on the ref that gets read. Because pushing a feature branch never moves the base's remote-tracking ref, the local base silently drifts behind and fabric would otherwise describe already-merged work
- Offline warning path - Emits a `could not refresh ... — diff may include already-merged commits` warning when the fetch fails, keeping the command usable offline while signaling the result may be wrong
- Test coverage - Added `tests/test-git.bats` cases verifying the base branch is fetched against the correct remote before diffing, and that a failed refresh still opens the PR with a warning
- Test helpers - Added a `fetch` case to the git stub and a `stub_failing_fetch` helper to simulate an offline run where the base cannot be refreshed but the stale copy is still diffable